### PR TITLE
Added method to 'search and read' in one request

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,6 +122,19 @@ Odoo.prototype.search = function (model, params, callback) {
   }, callback);
 };
 
+// Search & read records in one request. More efficient than 'search' followed by 'read'
+// https://www.odoo.com/documentation/8.0/api_integration.html#search-and-read
+Odoo.prototype.search = function (model, params, callback) {
+  this._request('/web/dataset/call_kw', {
+    kwargs: {
+      context: this.context
+    },
+    model: model,
+    method: 'search_read',
+    args: [params]
+  }, callback);
+};
+
 // Private functions
 Odoo.prototype._request = function (path, params, callback) {
   params = params || {};


### PR DESCRIPTION
Exposed the [search_read](https://www.odoo.com/documentation/8.0/api_integration.html#search-and-read) method of the Odoo API, a more efficient way to `search` and then `read` records.